### PR TITLE
[outdated] feat: add new layouts: threeColumns and spiral

### DIFF
--- a/lib/miguru/workspaces.ahk
+++ b/lib/miguru/workspaces.ahk
@@ -978,20 +978,28 @@ class WorkspaceList {
                 dir := cur_window[1]
                 x := cur_window[2], y := cur_window[3]
                 w := cur_window[4], h := cur_window[5]
-                if dir=="right"     return ["down", x + w + spacing * 2, y, w, h]
-                if dir=="down"      return ["left", x, y + h + spacing * 2, w, h]
-                if dir=="left"      return ["up"  , x - spacing * 2 - w, y, w, h]
-                if dir=="up"        return ["right",x, y - h - spacing * 2, w, h]
+                if dir=="right"     
+                    return ["down", x + w + spacing * 2, y, w, h]
+                if dir=="down"      
+                    return ["left", x, y + h + spacing * 2, w, h]
+                if dir=="left"      
+                    return ["up"  , x - spacing * 2 - w, y, w, h]
+                if dir=="up"        
+                    return ["right",x, y - h - spacing * 2, w, h]
             }
 
             get_first_window_in_container(cur_container){
                 dir := cur_container[1]
                 x := cur_container[2], y := cur_container[3]
                 w := cur_container[4], h := cur_container[5]
-                if dir=="right"     return ["right", x, y, Round(w/2) - spacing, h]
-                if dir=="down"      return ["down" , x, y, w, Round(h/2) - spacing]
-                if dir=="left"      return ["left" , x + Round(w/2) + spacing, y, Round(w/2) - spacing, h]
-                if dir=="up"        return ["up"   , x, y + Round(h/2) + spacing, w, Round(h/2) - spacing]
+                if dir=="right"     
+                    return ["right", x, y, Round(w/2) - spacing, h]
+                if dir=="down"      
+                    return ["down" , x, y, w, Round(h/2) - spacing]
+                if dir=="left"      
+                    return ["left" , x + Round(w/2) + spacing, y, Round(w/2) - spacing, h]
+                if dir=="up"        
+                    return ["up"   , x, y + Round(h/2) + spacing, w, Round(h/2) - spacing]
             }
 
             cur_container := [splitDirection,x,y,totalWidth,totalHeight]

--- a/lib/miguru/workspaces.ahk
+++ b/lib/miguru/workspaces.ahk
@@ -828,7 +828,6 @@ class WorkspaceList {
                 ; 1.3 should be replaced by an option
                 masterWidth := Round(usableWidth * opts.masterSize * 1.3)
                 slaveWidth := usableWidth - masterWidth
-                ; args: tile, count, x, startY, totalWidth, totalHeight
                 if(slaveCount == 1){
                     firstSlave := this._tallRetilePane(
                         this._tiled.First,
@@ -885,6 +884,7 @@ class WorkspaceList {
 
         _threeColumnsRetilePane(tile, count, left_x, left_y, right_x, right_y, totalWidth, totalHeight){
             spacing := this._opts.spacing > 0 && count > 1 ? this._opts.spacing // 2 : 0
+
             slave_left_num := Integer(count/2)
             slave_right_num := count - slave_left_num
             spacing_right := this._opts.spacing > 0 && slave_right_num > 1 ? this._opts.spacing // 2 : 0


### PR DESCRIPTION
add two new layouts

**layout 1: ThreeColumns**
If there are only two windows, the master pane takes up most of the space.

If there are more than two windows, the master pane moves to the middle, while the other windows are tiled on the left and right sides.

Specifically, the last `salveCount // 2` windows will move to the right side and tile in `Tall`, and the previous slave windows will move to the left side and tile in `Tall`.

**layout2: Spiral**
tile windows in a spiral (clockwise) direcion.

sorry for my poor coding style, but i think these two layouts should work fine